### PR TITLE
Update log.py

### DIFF
--- a/roadrunner/log.py
+++ b/roadrunner/log.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 
-FMT = "%(asctime)s %(level)s %(message)s"
+FMT = "%(asctime)s %(levelname)s %(message)s"
 
 
 def setup_logging(level=logging.DEBUG, stream=sys.stderr):


### PR DESCRIPTION
Replace level with levelname, otherwise the following exception is triggered:

Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/**init**.py", line 859, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/**init**.py", line 732, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/**init**.py", line 474, in format
    s = self._fmt % record.__dict__
KeyError: 'level'
Logged from file **init**.py, line 265
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/**init**.py", line 859, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/**init**.py", line 732, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/**init**.py", line 474, in format
    s = self._fmt % record.__dict__
KeyError: 'level'
Logged from file **init**.py, line 265
